### PR TITLE
Changed regex to allow PKCS#8 keys, too

### DIFF
--- a/src/cloudStorage.js
+++ b/src/cloudStorage.js
@@ -27,7 +27,7 @@ module.exports = function(privateKey, googleServicesEmail, storageBucket) {
 	}
 	
 	// Accepts paths too for private key
-	if(!privateKey.match(/BEGIN RSA PRIVATE KEY/))
+	if(!privateKey.match(/BEGIN (RSA )?PRIVATE KEY/))
 		privateKey = fs.readFileSync(privateKey,"utf8").toString();
 	
 	return CloudStorage = {


### PR DESCRIPTION
Google now recommends using the JSON file for keys, instead of the P12, and the public_key in that file is PKCS#8, so its header reads 'BEGIN PRIVATE KEY' instead of 'BEGIN RSA PRIVATE KEY'.  I just changed the regex to accept either one, and everything else worked fine .